### PR TITLE
Mark Moo::Lax as deprecated in META

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -24,6 +24,7 @@ repository.type = git
 [PruneCruft]
 [ManifestSkip]
 [MetaYAML]
+[MetaJSON]
 [License]
 [Readme]
 [ExtraTests]

--- a/dist.ini
+++ b/dist.ini
@@ -8,6 +8,11 @@ copyright_year   = 2014
 [Git::NextVersion]
 first_version = 0.10
 
+; This module is useless since Moo 2.0
+[Deprecated]
+:version = 0.004
+all = 1
+
 [MetaResources]
 homepage        = https://github.com/dams/p5-Moo-Lax
 bugtracker.web  = https://github.com/dams/p5-Moo-Lax/issues


### PR DESCRIPTION
As Moo::Lax is now a no-op (since Moo 2.0), we can now mark the distribution as deprecated in META.{yml,json}.

Also add META.json generation that was missing.